### PR TITLE
Support non-uniform array of relative humidity

### DIFF
--- a/climlab_sbm_convection/climlab_betts_miller.f90
+++ b/climlab_sbm_convection/climlab_betts_miller.f90
@@ -146,9 +146,10 @@ end subroutine escomp
 !! CLIMLAB add more input arguments,
 !! remove input coldT and output snow,
 !!  remove optional arguments mask and conv
-subroutine betts_miller (dt, tin, qin, pfull, phalf, &
+!! CLIMLAB also change call order, since rhbm is now an array input
+subroutine betts_miller (dt, tin, qin, rhbm, pfull, phalf, &
                         HLv,Cp_air,Grav,rdgas,rvgas,kappa, es0, &
-                        tau_bm_input, rhbm, do_simp, do_shallower, do_changeqref, &
+                        tau_bm_input, do_simp, do_shallower, do_changeqref, &
                         do_envsat, do_taucape, capetaubm, tau_min, &
                         ix, jx, kx, &
                         rain, tdel, qdel, q_ref, bmflag, &

--- a/climlab_sbm_convection/climlab_betts_miller.f90
+++ b/climlab_sbm_convection/climlab_betts_miller.f90
@@ -93,6 +93,7 @@ end subroutine escomp
 !                             do_envsat, do_taucape, capetaubm, tau_min
 
 ! CLIMLAB we will pass these nine switches/parameters as input:
+! CLIMLAB: rhbm is now an array parameter rather than scalar
 ! tau_bm, rhbm, do_simp, do_shallower, do_changeqref, do_envsat, do_taucape, capetaubm, tau_min
 
 
@@ -101,7 +102,7 @@ end subroutine escomp
 !
 !  tau_bm    =  betts-miller relaxation timescale (seconds)
 !
-!  rhbm      = relative humidity that you're relaxing towards
+!  rhbm      = relative humidity profile that you're relaxing towards
 !
 !  do_simp = do the simple method where you adjust timescales to make
 !            precip continuous always
@@ -194,6 +195,8 @@ subroutine betts_miller (dt, tin, qin, pfull, phalf, &
    integer, intent(in) :: ix, jx, kx
    !real   , intent(in) , dimension(:,:,:) :: tin, qin, pfull, phalf
    real, intent(in) :: tin(ix,jx,kx), qin(ix,jx,kx), pfull(ix,jx,kx), phalf(ix,jx,kx+1)
+   !! CLIMLAB rhbm is now array input
+   real, intent(in) :: rhbm(ix,jx,kx)
    real   , intent(in)                    :: dt
    !logical   , intent(in) :: coldT
    !real   , intent(out), dimension(:,:)   :: rain,snow, bmflag, klzbs, cape, &
@@ -203,7 +206,7 @@ subroutine betts_miller (dt, tin, qin, pfull, phalf, &
 
    !! CLIMLAB added new inputs
    real, intent(in) :: HLv,Cp_air,Grav,rdgas,rvgas,kappa, es0
-   real, intent(in) :: tau_bm_input, rhbm, capetaubm, tau_min
+   real, intent(in) :: tau_bm_input, capetaubm, tau_min
    logical, intent(in) :: do_simp, do_shallower, do_changeqref, do_envsat, &
        do_taucape
 
@@ -233,7 +236,7 @@ logical :: avgbl
 integer  i, j, k, klzb, ktop, klzb2
 
 !  These are not comments! Necessary directives to f2py to handle array dimensions
-!f2py depend(ix,jx,kx) p,phalf,tin,qin
+!f2py depend(ix,jx,kx) p,phalf,tin,qin,rhbm
 !f2py depend(ix,jx,kx) tdel,qdel,q_ref,t_ref
 !f2py depend(ix,jx) rain,bmflag,klzbs,cape,cin,invtau_bm_t,invtau_bm_q,capeflag
 
@@ -296,13 +299,13 @@ integer  i, j, k, klzb, ktop, klzb2
                    if(do_envsat) then
 !                      call establ2(es,tin(i,j,k))
                       call escomp(tin(i,j,k),es)
-                      es = es*rhbm
+                      es = es*rhbm(i,j,k)
 !                      rpc(k) = d622*es/(pfull(i,j,k) - d378*es)
                       rpc(k) = rdgas/rvgas*es/pfull(i,j,k)
                       q_ref(i,j,k) = rpc(k)/(1 + rpc(k))
                    else
-                      rpc(k) = rhbm*rpc(k)
-!                      eref(k) = rhbm*pfull(i,j,k)*rpc(k)/(d622 + d378*rpc(k))
+                      rpc(k) = rhbm(i,j,k)*rpc(k)
+!                      eref(k) = rhbm(i,j,k)*pfull(i,j,k)*rpc(k)/(d622 + d378*rpc(k))
 !                      rpc(k) = d622*eref(k)/(pfull(i,j,k) - d378*eref(k))
                       q_ref(i,j,k) = rpc(k)/(1 + rpc(k))
                    endif

--- a/climlab_sbm_convection/tests/test_sbm_convection.py
+++ b/climlab_sbm_convection/tests/test_sbm_convection.py
@@ -129,11 +129,12 @@ def test_betts_miller():
     qin_grid_moist = qin_moist[np.newaxis, np.newaxis, :]
     pfull_grid = pfull[np.newaxis, np.newaxis, :]
     phalf_grid = phalf[np.newaxis, np.newaxis, :]
+    rhbm_grid = rhbm * np.ones_like(tin_grid)
 
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
         betts_miller(dt, tin_grid, qin_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -150,7 +151,7 @@ def test_betts_miller():
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
     betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -159,12 +160,22 @@ def test_betts_miller():
     assert rain[0,0] == pytest.approx(1.4249854, rel=tol)
     assert bmflag[0,0] == 2
 
+    # Can we call the Betts-Miller routine with a non-unform profile of relative humidity?
+    rhbm_grid[:] = np.linspace(0.6, 0.9, num_lev)
+    rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
+    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+                                          HLv, Cp_air, Grav,
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          do_simp, do_shallower, do_changeqref, 
+                                          do_envsat, do_taucape, capetaubm, tau_min, 
+                                          ix, jx, kx,)
+
     # Make sure we can call the Betts-Miller routine with different option flags
     do_simp = True  # alternative way to conserve energy by adjusting the relaxation timescale on temperature rather than calculating an adjusted reference temperature. 
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
     betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -174,7 +185,7 @@ def test_betts_miller():
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
     betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -182,7 +193,7 @@ def test_betts_miller():
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
     betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -197,7 +208,7 @@ def test_betts_miller():
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
     betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -207,7 +218,7 @@ def test_betts_miller():
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
     betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)

--- a/climlab_sbm_convection/tests/test_sbm_convection.py
+++ b/climlab_sbm_convection/tests/test_sbm_convection.py
@@ -132,9 +132,9 @@ def test_betts_miller():
     rhbm_grid = rhbm * np.ones_like(tin_grid)
 
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-        betts_miller(dt, tin_grid, qin_grid, pfull_grid, phalf_grid, 
+        betts_miller(dt, tin_grid, qin_grid, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm,
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -149,9 +149,9 @@ def test_betts_miller():
 
     # Now destabilize the surface with added moisture
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+    betts_miller(dt, tin_grid, qin_grid_moist, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm,
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -163,9 +163,9 @@ def test_betts_miller():
     # Can we call the Betts-Miller routine with a non-unform profile of relative humidity?
     rhbm_grid[:] = np.linspace(0.6, 0.9, num_lev)
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+    betts_miller(dt, tin_grid, qin_grid_moist, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm, 
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -173,9 +173,9 @@ def test_betts_miller():
     # Make sure we can call the Betts-Miller routine with different option flags
     do_simp = True  # alternative way to conserve energy by adjusting the relaxation timescale on temperature rather than calculating an adjusted reference temperature. 
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+    betts_miller(dt, tin_grid, qin_grid_moist, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm,
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -183,17 +183,17 @@ def test_betts_miller():
     #  In this case, since we set do_changeqref = True, we use the scheme that involves
     #  changing the reference profiles for both temperature and humidity so the precipitation is zero
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+    betts_miller(dt, tin_grid, qin_grid_moist, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm,
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
     do_changeqref = False
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+    betts_miller(dt, tin_grid, qin_grid_moist, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm,
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -206,9 +206,9 @@ def test_betts_miller():
     # just multiplying by a specified relative humidity. 
     # In that sense, the target of the moisture adjustment due to convection is dictated by surface conditions.
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+    betts_miller(dt, tin_grid, qin_grid_moist, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm,
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)
@@ -216,9 +216,9 @@ def test_betts_miller():
     do_taucape = True
     #  this makes the relaxation time proportional to 1/sqrt(CAPE), and so makes the scheme more aggressive when / where the CAPE is larger.
     rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, invtau_bm_t, invtau_bm_q, capeflag = \
-    betts_miller(dt, tin_grid, qin_grid_moist, pfull_grid, phalf_grid, 
+    betts_miller(dt, tin_grid, qin_grid_moist, rhbm_grid, pfull_grid, phalf_grid, 
                                           HLv, Cp_air, Grav,
-                                          rdgas,rvgas,kappa, es0, tau_bm, rhbm_grid, 
+                                          rdgas,rvgas,kappa, es0, tau_bm,
                                           do_simp, do_shallower, do_changeqref, 
                                           do_envsat, do_taucape, capetaubm, tau_min, 
                                           ix, jx, kx,)

--- a/docs/simplified_betts_miller.py
+++ b/docs/simplified_betts_miller.py
@@ -124,9 +124,9 @@ class SimplifiedBettsMiller(TimeDependentProcess):
 
         (rain, tdel, qdel, q_ref, bmflag, klzbs, cape, cin, t_ref, \
         invtau_bm_t, invtau_bm_q, capeflag) = \
-            betts_miller(dt, T, Q, P, PH,
+            betts_miller(dt, T, Q, RHBM, P, PH,
                          HLv,Cp_air,Grav,rdgas,rvgas,kappa, es0,
-                         self.tau_bm, RHBM, self.do_simp, self.do_shallower,
+                         self.tau_bm, self.do_simp, self.do_shallower,
                          self.do_changeqref, self.do_envsat, self.do_taucape,
                          self.capetaubm, self.tau_min,self._IX, self._JX, self._KX, )
 

--- a/docs/simplified_betts_miller.py
+++ b/docs/simplified_betts_miller.py
@@ -59,6 +59,11 @@ class SimplifiedBettsMiller(TimeDependentProcess):
         self.add_input('do_changeqref', do_changeqref)
         self.add_input('do_envsat', do_envsat)
         self.add_input('do_taucape', do_taucape)
+        if hasattr(rhbm, 'shape'):
+            assert np.all(rhbm.shape == self.Tatm.shape), f'rhbm {rhbm.shape} has to have same shape as Tatm {self.Tatm.shape}'
+            self.rhbm = rhbm
+        else:
+            self.rhbm = rhbm * np.ones_like(self.Tatm)
 
         self._KX = self.lev.size
         try:
@@ -104,6 +109,7 @@ class SimplifiedBettsMiller(TimeDependentProcess):
         #  which is the same as climlab convention.
         #  All we have to do is ensure the input fields are (num_lat, num_lon, num_lev)
         T = self._climlab_to_sbm(self.state['Tatm'])
+        RHBM = self._climlab_to_sbm(self.rhbm)
         dom = self.state['Tatm'].domain
         P = self._climlab_to_sbm(dom.lev.points) * 100. # convert to Pascals
         PH = self._climlab_to_sbm(dom.lev.bounds) * 100.
@@ -120,7 +126,7 @@ class SimplifiedBettsMiller(TimeDependentProcess):
         invtau_bm_t, invtau_bm_q, capeflag) = \
             betts_miller(dt, T, Q, P, PH,
                          HLv,Cp_air,Grav,rdgas,rvgas,kappa, es0,
-                         self.tau_bm, self.rhbm, self.do_simp, self.do_shallower,
+                         self.tau_bm, RHBM, self.do_simp, self.do_shallower,
                          self.do_changeqref, self.do_envsat, self.do_taucape,
                          self.capetaubm, self.tau_min,self._IX, self._JX, self._KX, )
 


### PR DESCRIPTION
The `betts_miller` subroutine now expects array input for the parameter `rhbm` (the relative humidity values to which the scheme relaxes). This is a new feature not implemented in the original Fortran code.

Consistent with this change, the call signature for the subroutine has changed. The `rhbm` input has been moved up the list so that it is specified along with other array inputs.

Tests and documented examples were updated to reflect these changes.