### PR TITLE
Implement minimum pressure level in example climlab wrapper

### DIFF
--- a/docs/simplified_betts_miller.py
+++ b/docs/simplified_betts_miller.py
@@ -34,7 +34,7 @@ class SimplifiedBettsMiller(TimeDependentProcess):
                 do_taucape=False,
                 capetaubm=900.,  # only used if do_taucape == True
                 tau_min=2400.,   # only used if do_taucape == True
-                minimum_pressure=10.  # prevent the SBM scheme from modifying temperature and humidity above this level (in hPa)
+                minimum_pressure=10.,  # prevent the SBM scheme from modifying temperature and humidity above this level (in hPa)
                 **kwargs):
         super(SimplifiedBettsMiller, self).__init__(**kwargs)
         self.time_type = 'explicit'


### PR DESCRIPTION
Prevent the SBM scheme from modifying temperature and humidity above a specified minimum pressure level.

This is only in the climlab process code currently in the `docs` folder (to be migrated to climlab itself). No effect on `climlab-sbm-convection` fortran wrapper itself.